### PR TITLE
Allow limiting by VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Useful to keep track of the firewall changes in git.
 Can also be used as a backup in case you lose some rules on EC2.
 
 Usage:
-    ec2-security-groups-dumper --json
-    ec2-security-groups-dumper --csv
+    ec2-security-groups-dumper --json [--region=<region>] [--profile=<profile>]
+    ec2-security-groups-dumper --csv [--region=<region>] [--profile=<profile>]
     ec2-security-groups-dumper (-h | --help)
 
 Options:

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Useful to keep track of the firewall changes in git.
 Can also be used as a backup in case you lose some rules on EC2.
 
 Usage:
-    ec2-security-groups-dumper --json [--region=<region>] [--profile=<profile>]
-    ec2-security-groups-dumper --csv [--region=<region>] [--profile=<profile>]
+    ec2-security-groups-dumper --json [--region=<region>] [--profile=<profile>] [--vpc=<vpc>]
+    ec2-security-groups-dumper --csv [--region=<region>] [--profile=<profile>] [--vpc=<vpc>]
     ec2-security-groups-dumper (-h | --help)
 
 Options:

--- a/ec2_security_groups_dumper/main.py
+++ b/ec2_security_groups_dumper/main.py
@@ -112,6 +112,7 @@ class Firewall(object):
 
         assert type(region) is StringType, "The region must be a string."
         assert type(profile) is StringType, "The profile must be a string."
+        assert type(vpc) is StringType, "The vpc must be a string."
 
     @property
     def json(self):

--- a/ec2_security_groups_dumper/main.py
+++ b/ec2_security_groups_dumper/main.py
@@ -13,6 +13,7 @@ Options:
   -h --help                 Show this screen.
   --region=<region>         Set an AWS region
   --profile=<profile>       Set an AWS/Boto CLI profile
+  --vpc=<vpc>               Set a VPC ID to filter by
 
 Examples:
     ec2-security-groups-dumper --csv > path/to/ec2-security-groups.csv
@@ -100,6 +101,7 @@ class Firewall(object):
         Keyword arguments:
         region -- the AWS region to be queried
         profile --  the AWS profile to use
+        vpc -- the AWS VPC to filter by
         """
         self.region = region
         self.profile = profile

--- a/ec2_security_groups_dumper/main.py
+++ b/ec2_security_groups_dumper/main.py
@@ -114,8 +114,8 @@ class Firewall(object):
             "The region must be a string."
         assert type(profile) is StringType or NoneType, \
             "The profile must be a string."
-
         assert type(vpc) is StringType or NoneType, "The vpc must be a string."
+
     @property
     def json(self):
         """

--- a/ec2_security_groups_dumper/main.py
+++ b/ec2_security_groups_dumper/main.py
@@ -124,18 +124,32 @@ class Firewall(object):
                 for rule_row in main_row['rules']:
                     if 'grants' in rule_row:
                         for grant_row in rule_row['grants']:
-                            if 'group_id' in grant_row and 'name' in grant_row:
+                            if 'group_id' in grant_row:
                                 # Set a var to not go over 80 chars
                                 group_id = grant_row['group_id']
+
+                                # Some VPC grants don't specify a name
+                                if 'name' in grant_row:
+                                    row_name = grant_row['name']
+                                else:
+                                    row_name = None
+
+                                # Some VPC grants specify -1 instead for the
+                                # ip_protocol instead of not declaring it
+                                if rule_row['ip_protocol'] == u'-1':
+                                    row_ip_protocol = None
+                                else:
+                                    row_ip_protocol = rule_row['ip_protocol']
+
                                 fr = FirewallRule(
                                     main_row['id'],
                                     main_row['name'],
                                     main_row['description'],
-                                    rules_ip_protocol=rule_row['ip_protocol'],
+                                    rules_ip_protocol=row_ip_protocol,
                                     rules_from_port=rule_row['from_port'],
                                     rules_to_port=rule_row['to_port'],
                                     rules_grants_group_id=group_id,
-                                    rules_grants_name=grant_row['name'])
+                                    rules_grants_name=row_name)
                                 list_of_rules.append(fr)
                             elif 'cidr_ip' in grant_row:
                                 fr = FirewallRule(

--- a/ec2_security_groups_dumper/main.py
+++ b/ec2_security_groups_dumper/main.py
@@ -293,3 +293,7 @@ def main():
         print firewall.json
     elif arguments['--csv']:
         print firewall.csv
+
+
+if __name__ == '__main__':
+    main()

--- a/ec2_security_groups_dumper/main.py
+++ b/ec2_security_groups_dumper/main.py
@@ -110,9 +110,9 @@ class Firewall(object):
             self.filters['vpc_id'] = [vpc]
         self.dict_rules = self._get_rules_from_aws()
 
-        assert type(region) is StringType, "The region must be a string."
-        assert type(profile) is StringType, "The profile must be a string."
-        assert type(vpc) is StringType, "The vpc must be a string."
+        assert type(region) is StringType or NoneType, "The region must be a string."
+        assert type(profile) is StringType or NoneType, "The profile must be a string."
+        assert type(vpc) is StringType or NoneType, "The vpc must be a string."
 
     @property
     def json(self):

--- a/ec2_security_groups_dumper/main.py
+++ b/ec2_security_groups_dumper/main.py
@@ -6,8 +6,8 @@ Useful to keep track of the firewall changes in git.
 Can also be used as a backup in case you lose some rules on EC2.
 
 Usage:
-    ec2-security-groups-dumper --json
-    ec2-security-groups-dumper --csv
+    ec2-security-groups-dumper --json [--region=<region>]
+    ec2-security-groups-dumper --csv [--region=<region>]
     ec2-security-groups-dumper (-h | --help)
 
 Options:
@@ -93,7 +93,8 @@ class FirewallRule(object):
 
 class Firewall(object):
 
-    def __init__(self):
+    def __init__(self, region=None):
+        self.region = region
         self.dict_rules = self._get_rules_from_aws()
 
     @property
@@ -245,7 +246,10 @@ class Firewall(object):
         """
         list_of_rules = list()
 
-        conn = boto.connect_ec2()
+        if self.region:
+            conn = boto.ec2.connect_to_region(region_name=self.region)
+        else:
+            conn = boto.connect_ec2()
         security_groups = conn.get_all_security_groups()
         for group in security_groups:
             group_dict = dict()
@@ -287,7 +291,12 @@ class Firewall(object):
 def main():
     arguments = docopt(__doc__)
 
-    firewall = Firewall()
+    if '--region' in arguments:
+        region = region = arguments['--region']
+    else:
+        region = None
+
+    firewall = Firewall(region=region)
 
     if arguments['--json']:
         print firewall.json

--- a/ec2_security_groups_dumper/main.py
+++ b/ec2_security_groups_dumper/main.py
@@ -54,7 +54,7 @@ class FirewallRule(object):
         assert isinstance(id, unicode), "Invalid id: {}".format(id)
         assert isinstance(name, unicode)
         assert isinstance(description, unicode)
-        assert rules_ip_protocol in (u'tcp', u'udp', u'icmp', None)
+        assert rules_ip_protocol in (u'tcp', u'udp', u'icmp', "-1", None)
         assert isinstance(rules_from_port, (unicode, NoneType))
         assert isinstance(rules_to_port, (unicode, NoneType))
         assert isinstance(rules_grants_group_id, (unicode, NoneType))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='ec2-security-groups-dumper',
-    version='1.1',
+    version='1.2',
     description='AWS EC2 Security Groups dump tool',
     url='https://github.com/percolate/ec2-security-groups-dumper',
     author='Laurent Raufaste',


### PR DESCRIPTION
Basic option to allow limiting the request by VPC (useful if you have different rules which overlap in different VPC's and want to look at each one individually).

Side note: commit history might want squashing, git bit me, I bit it. Nobody won.